### PR TITLE
Add maven step to list all ECharts file names in a file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,30 @@
 
   <build>
       <plugins>
+        <plugin>
+          <artifactId>maven-antrun-plugin</artifactId>
+          <version>3.0.0</version>
+          <executions>
+            <execution>
+              <phase>test</phase>
+              <configuration>
+                <target>
+                  <fileset id="echarts-fileset" dir="${build.outputDirectory}" />
+                  <pathconvert targetos="unix" pathsep=","
+                               property="echarts-file-list" refid="echarts-fileset">
+                    <map from="${build.outputDirectory}" to="" />
+                  </pathconvert>
+                  <!--suppress MavenModelInspection -->
+                  <echo file="${build.outputDirectory}/echarts-content.txt">${echarts-file-list}</echo>
+                </target>
+              </configuration>
+              <goals>
+                <goal>run</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+
         <!-- clean lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#clean_Lifecycle -->
         <plugin>
           <artifactId>maven-clean-plugin</artifactId>


### PR DESCRIPTION
Damit können wir ein Listing aller ECharts files erstellen, die im JAR liegen. Damit können wir hinterher mit dem Classloader diese Files in den Tmp Ordner kopieren.